### PR TITLE
Change conda-build version to >=2.0.4

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,7 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda update --yes conda
-conda install -c https://conda.anaconda.org/omnia --yes conda-build=2.0.2 jinja2 anaconda-client pip python-coveralls
+conda install -c https://conda.anaconda.org/omnia --yes conda-build>=2.0.4 jinja2 anaconda-client pip python-coveralls
 
 # Restore original directory
 popd


### PR DESCRIPTION
Why:

`conda-build` was previously pinned to 2.0.2 because of some issues introduced in newer versions. 


This should be fixed in 2.0.4 or greater.

This change addresses the need by:

Changing the conda-build version to >=2.0.4 in `install.sh`.